### PR TITLE
Create SharedServiceSlice resource in current namespace

### DIFF
--- a/pkg/apis/aerogear/v1alpha1/types.go
+++ b/pkg/apis/aerogear/v1alpha1/types.go
@@ -148,8 +148,9 @@ type SharedServiceSlice struct {
 }
 
 type SharedServiceSliceSpec struct {
-	ServiceType string                 `json:"service_type"`
-	Params      map[string]interface{} `json:"params"`
+	ServiceType 	 string                 `json:"service_type"`
+	Params      	 map[string]interface{} `json:"params"`
+	SliceNamespace string									`json:"slice_namespace"`
 	// Fill me
 }
 type SharedServiceSliceStatus struct {

--- a/pkg/broker/server/server.go
+++ b/pkg/broker/server/server.go
@@ -135,9 +135,6 @@ func (s *server) createServiceInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Check if parameters are required, if not, this thing below is ok to leave in,
-	// if they are ,they should be checked. Because if no parameters are passed in, this will
-	// fail because req.Parameters is nil.
 	if req.Parameters == nil {
 		req.Parameters = make(map[string]interface{})
 	}


### PR DESCRIPTION
## Description
Allow slice provision by creating a SharedServiceSlice resource in the broker namespace.

## Progress
- [x] Create SharedServiceSlice resource in the broker namespace when slice provision endpoint is called.
- [x] Added the `slice_namespace` property to be used for defaulting realm name to the slice namespace.
- [x] Use `ServiceType` instead of `ServiceName` for the SharedServiceSlice service type.

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/AEROGEAR-7564
Related PR - https://github.com/aerogear/keycloak-operator/pull/5

**Verification**
1. Have the Keycloak Operator & Managed Service Broker running on the same namespace
2. Create a [SharedService custom resource](https://github.com/aerogear/keycloak-operator/blob/master/deploy/examples/sharedservice.json) within the same namespace.
3. Create a [SharedServicePlan custom resource](https://github.com/aerogear/keycloak-operator/blob/master/deploy/examples/sharedserviceplan.yaml) within the same namespace.
4. Add the following to the SharedService custom resource created in Step 2.
```
spec
  ...
status:
  ready: true
```
5. Select `example-slice` from the Catalog and provision to a different namespace.
6. Ensure that a SharedServiceSlice custom resource is created in the namespace where the broker and the operator is.
7. Ensure the SharedServiceSice has the correct `params`, `service_type` and `slice_namespace` values.
8. Ensure that you can provision an `example-slice` from the Catalog without specifying a Realm name.
9. Ensure that the SharedServiceSlice custom resource created has an empty object value for the `params` property.