### PR TITLE
add che and launcher deployer

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -14,7 +14,9 @@ import (
 	"github.com/aerogear/managed-services-broker/pkg/broker/controller"
 	"github.com/aerogear/managed-services-broker/pkg/broker/server"
 	"github.com/aerogear/managed-services-broker/pkg/clients/openshift"
+	"github.com/aerogear/managed-services-broker/pkg/deploys/che"
 	"github.com/aerogear/managed-services-broker/pkg/deploys/fuse"
+	"github.com/aerogear/managed-services-broker/pkg/deploys/launcher"
 	"github.com/operator-framework/operator-sdk/pkg/k8sclient"
 	"github.com/pkg/errors"
 	glog "github.com/sirupsen/logrus"
@@ -79,6 +81,8 @@ func runWithContext(ctx context.Context) error {
 	ctrlr := controller.CreateController(namespace, k8sClient, osClient)
 
 	ctrlr.RegisterDeployer(fuse.NewDeployer("fuse-deployer"))
+	ctrlr.RegisterDeployer(launcher.NewDeployer("launcher-deployer"))
+	ctrlr.RegisterDeployer(che.NewDeployer("che-deployer"))
 	ctrlr.Catalog()
 
 	if options.TLSCert == "" && options.TLSKey == "" {

--- a/pkg/deploys/che/deployer.go
+++ b/pkg/deploys/che/deployer.go
@@ -1,0 +1,52 @@
+package che
+
+import (
+	"net/http"
+	"os"
+
+	brokerapi "github.com/aerogear/managed-services-broker/pkg/broker"
+	"github.com/aerogear/managed-services-broker/pkg/clients/openshift"
+	glog "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+)
+
+type CheDeployer struct {
+	id string
+}
+
+func NewDeployer(id string) *CheDeployer {
+	return &CheDeployer{id: id}
+}
+
+func (fd *CheDeployer) DoesDeploy(serviceID string) bool {
+	return serviceID == "che-service-id"
+}
+
+func (fd *CheDeployer) GetCatalogEntries() []*brokerapi.Service {
+	glog.Infof("Getting che catalog entries")
+	return getCatalogServicesObj()
+}
+
+func (fd *CheDeployer) GetID() string {
+	return fd.id
+}
+
+func (fd *CheDeployer) Deploy(instanceID, brokerNamespace string, contextProfile brokerapi.ContextProfile, k8sclient kubernetes.Interface, osClientFactory *openshift.ClientFactory) (*brokerapi.CreateServiceInstanceResponse, error) {
+	glog.Infof("Deploying che from deployer, id: %s", instanceID)
+
+	dashboardUrl := os.Getenv("CHE_DASHBOARD_URL")
+
+	return &brokerapi.CreateServiceInstanceResponse{
+		Code:         http.StatusAccepted,
+		DashboardURL: dashboardUrl,
+	}, nil
+}
+
+func (fd *CheDeployer) LastOperation(instanceID string, k8sclient kubernetes.Interface, osclient *openshift.ClientFactory) (*brokerapi.LastOperationResponse, error) {
+	glog.Infof("Getting last operation for %s", instanceID)
+
+	return &brokerapi.LastOperationResponse{
+		State:       brokerapi.StateSucceeded,
+		Description: "che deployed successfully",
+	}, nil
+}

--- a/pkg/deploys/che/objects.go
+++ b/pkg/deploys/che/objects.go
@@ -1,0 +1,33 @@
+package che
+
+import (
+	brokerapi "github.com/aerogear/managed-services-broker/pkg/broker"
+)
+
+// Che plan
+func getCatalogServicesObj() []*brokerapi.Service {
+	return []*brokerapi.Service{
+		{
+			Name:        "che",
+			ID:          "che-service-id",
+			Description: "che",
+			Metadata:    map[string]string{"serviceName": "che", "serviceType": "che"},
+			Plans: []brokerapi.ServicePlan{
+				brokerapi.ServicePlan{
+					Name:        "default-che",
+					ID:          "default-che",
+					Description: "default che plan",
+					Free:        true,
+					Schemas: &brokerapi.Schemas{
+						ServiceBinding: &brokerapi.ServiceBindingSchema{
+							Create: &brokerapi.RequestResponseSchema{},
+						},
+						ServiceInstance: &brokerapi.ServiceInstanceSchema{
+							Create: &brokerapi.InputParametersSchema{},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/deploys/fuse/objects.go
+++ b/pkg/deploys/fuse/objects.go
@@ -22,8 +22,8 @@ func getCatalogServicesObj() []*brokerapi.Service {
 			Metadata:    map[string]string{"serviceName": "fuse", "serviceType": "fuse"},
 			Plans: []brokerapi.ServicePlan{
 				brokerapi.ServicePlan{
-					Name:        "default",
-					ID:          "default",
+					Name:        "default-fuse",
+					ID:          "default-fuse",
 					Description: "default fuse plan",
 					Free:        true,
 					Schemas: &brokerapi.Schemas{

--- a/pkg/deploys/launcher/deployer.go
+++ b/pkg/deploys/launcher/deployer.go
@@ -1,0 +1,52 @@
+package launcher
+
+import (
+	"net/http"
+	"os"
+
+	brokerapi "github.com/aerogear/managed-services-broker/pkg/broker"
+	"github.com/aerogear/managed-services-broker/pkg/clients/openshift"
+	glog "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+)
+
+type LauncherDeployer struct {
+	id string
+}
+
+func NewDeployer(id string) *LauncherDeployer {
+	return &LauncherDeployer{id: id}
+}
+
+func (fd *LauncherDeployer) DoesDeploy(serviceID string) bool {
+	return serviceID == "launcher-service-id"
+}
+
+func (fd *LauncherDeployer) GetCatalogEntries() []*brokerapi.Service {
+	glog.Infof("Getting launcher catalog entries")
+	return getCatalogServicesObj()
+}
+
+func (fd *LauncherDeployer) GetID() string {
+	return fd.id
+}
+
+func (fd *LauncherDeployer) Deploy(instanceID, brokerNamespace string, contextProfile brokerapi.ContextProfile, k8sclient kubernetes.Interface, osClientFactory *openshift.ClientFactory) (*brokerapi.CreateServiceInstanceResponse, error) {
+	glog.Infof("Deploying launcher from deployer, id: %s", instanceID)
+
+	dashboardUrl := os.Getenv("LAUNCHER_DASHBOARD_URL")
+
+	return &brokerapi.CreateServiceInstanceResponse{
+		Code:         http.StatusAccepted,
+		DashboardURL: dashboardUrl,
+	}, nil
+}
+
+func (fd *LauncherDeployer) LastOperation(instanceID string, k8sclient kubernetes.Interface, osclient *openshift.ClientFactory) (*brokerapi.LastOperationResponse, error) {
+	glog.Infof("Getting last operation for %s", instanceID)
+
+	return &brokerapi.LastOperationResponse{
+		State:       brokerapi.StateSucceeded,
+		Description: "launcher deployed successfully",
+	}, nil
+}

--- a/pkg/deploys/launcher/objects.go
+++ b/pkg/deploys/launcher/objects.go
@@ -1,0 +1,31 @@
+package launcher
+
+import (
+	brokerapi "github.com/aerogear/managed-services-broker/pkg/broker"
+)
+
+// Launcher plan
+func getCatalogServicesObj() []*brokerapi.Service {
+	return []*brokerapi.Service{
+		{
+			Name:        "launcher",
+			ID:          "launcher-service-id",
+			Description: "launcher",
+			Metadata:    map[string]string{"serviceName": "launcher", "serviceType": "launcher"},
+			Plans: []brokerapi.ServicePlan{
+				brokerapi.ServicePlan{
+					Name:        "default-launcher",
+					ID:          "default-launcher",
+					Description: "default launcher plan",
+					Free:        true,
+					Schemas: &brokerapi.Schemas{
+						ServiceBinding: &brokerapi.ServiceBindingSchema{
+							Create: &brokerapi.RequestResponseSchema{},
+						},
+						ServiceInstance: &brokerapi.ServiceInstanceSchema{},
+					},
+				},
+			},
+		},
+	}
+}

--- a/templates/broker.template.yaml
+++ b/templates/broker.template.yaml
@@ -53,6 +53,10 @@ objects:
                   fieldPath: metadata.namespace
             - name: ROUTE_SUFFIX
               value: ${ROUTE_SUFFIX}
+            - name: LAUNCHER_DASHBOARD_URL
+              value: ${LAUNCHER_DASHBOARD_URL}
+            - name: CHE_DASHBOARD_URL
+              value: ${CHE_DASHBOARD_URL}
             ports:
             - containerPort: 8080
             readinessProbe:
@@ -115,6 +119,14 @@ parameters:
 
   - name: ROUTE_SUFFIX
     description: Cluster route subdomain
+    required: true
+
+  - name: LAUNCHER_DASHBOARD_URL
+    description: Launcher dasbhoard url
+    required: true
+  
+  - name: CHE_DASHBOARD_URL
+    description: Che dasbhoard url
     required: true
 
   - name: CA_BUNDLE


### PR DESCRIPTION
## Description
Add deployers for che and launcher to expose a service class to the catalog and to return the dashboard url to the provisioned service instance.

## Progress
- [x] Add Che deployer
- [x] Add launcher deployer
- [x] Add Che and Launcher dashboard URL as parameters to the broker template to be used as an env var

## Verification Steps
**NOTE: To be verified with https://github.com/integr8ly/installation/pull/34**

- Ensure that Che/Launcher can be seen in the service catalog
- Provision Che/Launcher
- Ensure that Che/Launcher's dashboard URL is available on the service instance once provision is finished.