### PR TITLE
update user namespace param according to changes in the syndesis operator

### DIFF
--- a/pkg/deploys/fuse/objects.go
+++ b/pkg/deploys/fuse/objects.go
@@ -383,7 +383,7 @@ func getFuseObj(userNamespace string) *v1alpha1.Syndesis {
 			Name: "fuse",
 		},
 		Spec: v1alpha1.SyndesisSpec{
-			UserNamespace:        userNamespace,
+			SarNamespace:         userNamespace,
 			DemoData:             &demoData,
 			DeployIntegrations:   &deployIntegrations,
 			ImageStreamNamespace: "",

--- a/pkg/deploys/fuse/pkg/apis/syndesis/v1alpha1/types.go
+++ b/pkg/deploys/fuse/pkg/apis/syndesis/v1alpha1/types.go
@@ -41,7 +41,7 @@ type SyndesisSpec struct {
 	Registry             string          `json:"registry,omitempty"`
 	Components           ComponentsSpec  `json:"components,omitempty"`
 	OpenShiftConsoleUrl  string          `json:"openShiftConsoleUrl,omitempty"`
-	UserNamespace        string          `json:"userNamespace,omitempty"`
+	SarNamespace         string          `json:"sarNamespace,omitempty"`
 }
 
 type IntegrationSpec struct {


### PR DESCRIPTION
## Description
Change the name of the userNamespace parameter to `sarNamespace` according to the feedback received in the syndesis operator [PR](https://github.com/syndesisio/syndesis/pull/3485).