### PR TITLE
Local development updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ build_image: build_binary
 .phony: build_binary
 build_binary:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./tmp/_output/bin/$(BROKER_IMAGE_NAME) ./cmd/broker
+
+.phony: run
+run:
+	KUBERNETES_CONFIG=$(HOME)/.kube/config ./tmp/_output/bin/managed-services-broker --port 8080

--- a/templates/broker.local.template.yml
+++ b/templates/broker.local.template.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: msb
+objects:
+  - apiVersion: servicecatalog.k8s.io/v1beta1
+    kind: ClusterServiceBroker
+    metadata:
+      name: msb-local
+    spec:
+      url: ${URL}
+
+parameters:
+- name: URL
+  description: Url to local running broker
+  value: "http://192.168.99.1:8080"


### PR DESCRIPTION
# Description

Add instructions on how to run the broker locally in development and test changes in minishift VM. Should also work for a local "oc cluster up", but untested.

Small change to remove the dependency on the deployment resource existing.

# Verification

Run through the steps of the "local development" section of the README here https://github.com/aerogear/managed-services-broker/tree/local-dev#local-development-minishift


