### PR TITLE
Update fuse to 7.1

### DIFF
--- a/pkg/deploys/fuse/objects.go
+++ b/pkg/deploys/fuse/objects.go
@@ -222,12 +222,12 @@ func getImageStreamObj() *imagev1.ImageStream {
 				{
 					From: &corev1.ObjectReference{
 						Kind: "DockerImage",
-						Name: "docker.io/jameelb/syndesis-operator:latest", // NOTE: Point this to own version of syndesis-operator for auth
+						Name: "docker.io/jameelb/syndesis-operator:1.4.8", // NOTE: Point this to own version of syndesis-operator for auth
 					},
 					ImportPolicy: imagev1.TagImportPolicy{
 						Scheduled: true,
 					},
-					Name: "latest",
+					Name: "fuse-7.1",
 				},
 			},
 		},
@@ -297,7 +297,7 @@ func getDeploymentConfigObj() *appsv1.DeploymentConfig {
 						},
 						From: corev1.ObjectReference{
 							Kind: "ImageStreamTag",
-							Name: "syndesis-operator:latest",
+							Name: "syndesis-operator:fuse-7.1",
 						},
 					},
 					Type: "ImageChange",


### PR DESCRIPTION
## Description
Update Fuse to 7.1 release. 

This is now using the [Syndesis operator image](https://hub.docker.com/r/jameelb/syndesis-operator/tags/) tagged as 1.4.8 which contains the release for Fuse 7.1 and the changes in this [PR](https://github.com/syndesisio/syndesis/pull/3485). 

## Verification Steps

1. Build and push the broker image: `make build_and_push DOCKERORG=<yourDockerOrg>`
2. Update the managed service broker in your cluster to use this image
3. Provision Fuse from the service catalog
4. Ensure that the image the `Syndesis Operator` is using has the correct image tag `1.4.8`
5. Ensure that Fuse provisions successfully.
6. Ensure that the user who provisioned Fuse can access the Fuse dasbhoard.