### PR TITLE
Add originating user view permissions on fuse namespace

### DIFF
--- a/pkg/broker/server/server.go
+++ b/pkg/broker/server/server.go
@@ -140,6 +140,10 @@ func (s *server) createServiceInstance(w http.ResponseWriter, r *http.Request) {
 		util.WriteErrorResponse(w, http.StatusBadRequest, err)
 		return
 	}
+	if err := util.GetOriginatingUserInfo(r, &req.OriginatingUserInfo); err != nil {
+		glog.Errorf("error retrieving originating user info: %v", err)
+		util.WriteErrorResponse(w, http.StatusBadRequest, err)
+	}
 
 	if req.Parameters == nil {
 		req.Parameters = make(map[string]interface{})

--- a/pkg/broker/types.go
+++ b/pkg/broker/types.go
@@ -1,5 +1,7 @@
 package broker
 
+import "k8s.io/api/authentication/v1"
+
 // Service represents a service (of which there may be many variants-- "plans")
 // offered by a service broker
 //
@@ -47,13 +49,14 @@ type ServiceInstance struct {
 // CreateServiceInstanceRequest represents a request to a broker to provision an
 // instance of a service
 type CreateServiceInstanceRequest struct {
-	OrgID             string                 `json:"organization_guid,omitempty"`
-	PlanID            string                 `json:"plan_id,omitempty"`
-	ServiceID         string                 `json:"service_id,omitempty"`
-	SpaceID           string                 `json:"space_guid,omitempty"`
-	Parameters        map[string]interface{} `json:"parameters,omitempty"`
-	AcceptsIncomplete bool                   `json:"accepts_incomplete,omitempty"`
-	ContextProfile    ContextProfile         `json:"context,omitempty"`
+	OrgID               string                 `json:"organization_guid,omitempty"`
+	PlanID              string                 `json:"plan_id,omitempty"`
+	ServiceID           string                 `json:"service_id,omitempty"`
+	SpaceID             string                 `json:"space_guid,omitempty"`
+	Parameters          map[string]interface{} `json:"parameters,omitempty"`
+	AcceptsIncomplete   bool                   `json:"accepts_incomplete,omitempty"`
+	ContextProfile      ContextProfile         `json:"context,omitempty"`
+	OriginatingUserInfo v1.UserInfo            `json:"user,omitempty"`
 }
 
 // ContextProfilePlatformKubernetes is a constant to send when the

--- a/pkg/deploys/che/deployer.go
+++ b/pkg/deploys/che/deployer.go
@@ -1,6 +1,7 @@
 package che
 
 import (
+	"k8s.io/api/authentication/v1"
 	"net/http"
 	"os"
 
@@ -31,7 +32,7 @@ func (fd *CheDeployer) GetID() string {
 	return fd.id
 }
 
-func (fd *CheDeployer) Deploy(instanceID, brokerNamespace string, contextProfile brokerapi.ContextProfile, k8sclient kubernetes.Interface, osClientFactory *openshift.ClientFactory) (*brokerapi.CreateServiceInstanceResponse, error) {
+func (fd *CheDeployer) Deploy(instanceID, brokerNamespace string, contextProfile brokerapi.ContextProfile, userInfo v1.UserInfo, k8sclient kubernetes.Interface, osClientFactory *openshift.ClientFactory) (*brokerapi.CreateServiceInstanceResponse, error) {
 	glog.Infof("Deploying che from deployer, id: %s", instanceID)
 
 	dashboardUrl := os.Getenv("CHE_DASHBOARD_URL")

--- a/pkg/deploys/fuse/objects.go
+++ b/pkg/deploys/fuse/objects.go
@@ -179,6 +179,30 @@ func getViewRoleBindingObj() *authv1.RoleBinding {
 	}
 }
 
+func getUserViewRoleBindingObj(namespace, username string) *authv1.RoleBinding {
+	return &authv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "syndesis-operator:view-",
+			Namespace:    namespace,
+			Labels: map[string]string{
+				"app":                   "syndesis",
+				"syndesis.io/app":       "syndesis",
+				"syndesis.io/type":      "operator",
+				"syndesis.io/component": "syndesis-operator",
+			},
+		},
+		RoleRef: corev1.ObjectReference{
+			Name: "view",
+		},
+		Subjects: []corev1.ObjectReference{
+			{
+				Kind: "User",
+				Name: username,
+			},
+		},
+	}
+}
+
 func getEditRoleBindingObj() *authv1.RoleBinding {
 	return &authv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/deploys/launcher/deployer.go
+++ b/pkg/deploys/launcher/deployer.go
@@ -1,6 +1,7 @@
 package launcher
 
 import (
+	"k8s.io/api/authentication/v1"
 	"net/http"
 	"os"
 
@@ -31,7 +32,7 @@ func (fd *LauncherDeployer) GetID() string {
 	return fd.id
 }
 
-func (fd *LauncherDeployer) Deploy(instanceID, brokerNamespace string, contextProfile brokerapi.ContextProfile, k8sclient kubernetes.Interface, osClientFactory *openshift.ClientFactory) (*brokerapi.CreateServiceInstanceResponse, error) {
+func (fd *LauncherDeployer) Deploy(instanceID, brokerNamespace string, contextProfile brokerapi.ContextProfile, userInfo v1.UserInfo, k8sclient kubernetes.Interface, osClientFactory *openshift.ClientFactory) (*brokerapi.CreateServiceInstanceResponse, error) {
 	glog.Infof("Deploying launcher from deployer, id: %s", instanceID)
 
 	dashboardUrl := os.Getenv("LAUNCHER_DASHBOARD_URL")


### PR DESCRIPTION
## Description
Create a user view role binding for the originating user on the newly created fuse namespace.

## Verification
1. Build and Deploy the broker image to your test cluster
1. Create a user that has no elevated permissions
1. Provision fuse from the catalog as the test user
1. Verify that you can view the newly created fuse namespace and access the logs of pods.