### PR TITLE
limit permissions given to the broker

### DIFF
--- a/templates/broker.template.yaml
+++ b/templates/broker.template.yaml
@@ -96,65 +96,86 @@ objects:
       name: managed-services-broker
     spec:
       url: http://msb.${NAMESPACE}.svc
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
-    kind: Role
-    metadata:
-      name: managed-services
-    rules:
-    - apiGroups:
-      - aerogear.org
-      - syndesis.io
-      resources:
-      - "*"
-      verbs:
-      - "*"
-    - apiGroups:
-      - ""
-      resources:
-      - pods
-      - services
-      - endpoints
-      - persistentvolumeclaims
-      - events
-      - configmaps
-      - secrets
-      - namespaces
-      - serviceaccounts
-      verbs:
-      - "*"
-    - apiGroups:
-      - apps
-      resources:
-      - deployments
-      - daemonsets
-      - replicasets
-      - statefulsets
-      verbs:
-      - "*"
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
-    kind: RoleBinding
-    metadata:
-      name: default-account-managed-services
-    subjects:
-    - kind: ServiceAccount
-      name: default
-    roleRef:
-      kind: Role
-      name: managed-services
-      apiGroup: rbac.authorization.k8s.io
-
-  - apiVersion: rbac.authorization.k8s.io/v1
+  - apiVersion: authorization.openshift.io/v1
     kind: ClusterRole
     metadata:
       name: managed-services
     rules:
     - apiGroups:
-      - "*"
+      - ""
       resources:
-      - "*"
-      verbs:
-      - "*"
+      - namespaces
+      verbs: ["create"]
+    - apiGroups:
+      - rbac.authorization.k8s.io
+      resourceNames: ["edit", "view", "system:deployer", "system:image-builder", "system:image-puller"]
+      resources:
+      - clusterroles
+      verbs: ["bind"]
+    - apiGroups:
+      - rbac.authorization.k8s.io
+      resources:
+      - roles
+      verbs: ["create"]
+    - apiGroups:
+      - syndesis.io
+      resources:
+      - syndesises
+      - syndesises/finalizers
+      verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - endpoints
+      - persistentvolumeclaims
+      - pods
+      - secrets
+      - serviceaccounts
+      - services
+      verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs: ["get", "list"]
+    - apiGroups:
+      - rbac.authorization.k8s.io
+      resources:
+      - rolebindings
+      verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
+    - apiGroups:
+      - template.openshift.io
+      resources:
+      - processedtemplates
+      verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
+    - apiGroups:
+      - image.openshift.io
+      resources:
+      - imagestreams
+      verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
+    - apiGroups:
+      - apps.openshift.io
+      resources:
+      - deploymentconfigs
+      verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
+    - apiGroups:
+      - build.openshift.io
+      resources:
+      - buildconfigs
+      verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
+    - apiGroups:
+      - authorization.openshift.io
+      resources:
+      - rolebindings
+      verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
+    - apiGroups:
+      - route.openshift.io
+      resources:
+      - routes
+      - routes/custom-host
+      verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
 
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding


### PR DESCRIPTION
## Description
Remove the role and rolebinding which is currently not needed by the broker.
Limit the permissions given to the broker in cluster role. The broker only needs the following permissions:

- create namespaces and roles (for deploying fuse)
- ability to bind to `system:deployer`, `system:image-builder`, `system:image-puller` cluster roles. (This is needed due to missing default system role bindings when a new namespace is created in **v3.9.0**, this has been fixed in **v3.10**)
- ability to bind to `edit` and `view` cluster role (needed by the fuse operator)
- permissions granted in the role created for the [fuse operator](https://github.com/syndesisio/syndesis/blob/master/install/operator/deploy/syndesis-operator.yml#L12-L80).

## Verification Steps

1. Deploy the managed-services-broker using this template.
2. Ensure that the managed services broker is deployed and all of its required resources are created succesfully.
3. Ensure that Fuse, Che and Launcher deploys successfully.
